### PR TITLE
navigation initialized with kwargs (including variables coming from p…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 0.1.2 (unreleased)
 ==================
 
-- Nothing changed yet.
+- navigation supports kwargs (pytest variables available too)
 
 
 0.1.1 (2017-10-30)

--- a/pypom_navigation/navigation.py
+++ b/pypom_navigation/navigation.py
@@ -19,13 +19,15 @@ class Navigation(object):
                  page_mappings,
                  credentials_mapping,
                  skin,
-                 skin_base_url):
+                 skin_base_url,
+                 **kwargs):
         self.setPage(page)
         self.default_page_class = default_page_class
         self.page_mappings = page_mappings
         self.credentials_mapping = credentials_mapping
         self.skin = skin
         self.skin_base_url = skin_base_url
+        self.kwargs = kwargs
 
     def setPage(self, page, page_id=None):
         """ Set wrapping page and update reference links

--- a/pypom_navigation/plugin.py
+++ b/pypom_navigation/plugin.py
@@ -204,7 +204,8 @@ def navigation(navigation_class,
                page_mappings,
                credentials_mapping,
                skin,
-               skin_base_url):
+               skin_base_url,
+               variables):
     """ Wraps a page and a page mappings accessible by
         pages.
 
@@ -218,7 +219,8 @@ def navigation(navigation_class,
         page_mappings,
         credentials_mapping,
         skin,
-        skin_base_url)
+        skin_base_url,
+        variables=variables,)
     return nav
 
 

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -3,6 +3,11 @@ from mock import MagicMock
 
 
 @pytest.fixture
+def variables():
+    return {'foo': 'bar'}
+
+
+@pytest.fixture
 def page_instance():
     return MagicMock()
 
@@ -68,7 +73,8 @@ def test_visit_page(navigation, page_instance, default_page_class):
     assert home_page.driver.visit.assert_called_once_with(
         'https://skin1-coolsite.com/home') is None
     assert home_page.wait_for_page_to_load.assert_called_once() is None
-    assert default_page_class.assert_called_once_with(page_instance.driver) is None
+    assert default_page_class.assert_called_once_with(
+        page_instance.driver) is None
     assert default_page_class.return_value.navigation is navigation
 
 
@@ -78,7 +84,8 @@ def test_update_page(navigation, page_instance, default_page_class):
     assert navigation.page is home_page
     assert navigation.page_id == 'HomePage'
     assert home_page.wait_for_page_to_load.assert_called_once() is None
-    assert default_page_class.assert_called_once_with(page_instance.driver) is None
+    assert default_page_class.assert_called_once_with(
+        page_instance.driver) is None
     assert default_page_class.return_value.navigation is navigation
 
 
@@ -89,26 +96,31 @@ def test_action_performed(navigation, page_instance, default_page_class):
     assert navigation.page is home_page
     assert navigation.page_id == 'HomePage'
     assert home_page.wait_for_page_to_load.assert_called_once() is None
-    assert default_page_class.assert_called_once_with(page_instance.driver) is None
+    assert default_page_class.assert_called_once_with(
+         page_instance.driver) is None
     assert default_page_class.return_value.navigation is navigation
 
 
-def test_action_performed_no_action_mapped(navigation, page_instance, default_page_class):
+def test_action_performed_no_action_mapped(navigation, page_instance,
+                                           default_page_class):
     """ Test visit page """
     navigation.setPage(page_instance, 'AnotherPage')
     default_page = navigation.action_performed('unknown')
     assert navigation.page is default_page
     assert navigation.page_id is None
     assert default_page.wait_for_page_to_load.assert_called_once() is None
-    assert default_page_class.assert_called_once_with(page_instance.driver) is None
+    assert default_page_class.assert_called_once_with(
+        page_instance.driver) is None
     assert default_page_class.return_value.navigation is navigation
 
 
-def test_action_performed_fallback(navigation, page_instance, default_page_class):
+def test_action_performed_fallback(navigation, page_instance,
+                                   default_page_class):
     """ Test visit page """
     navigation.setPage(page_instance, 'AnotherPage')
     fallback_class = MagicMock()
-    fallback_page = navigation.action_performed('unknown', fallback=fallback_class)
+    fallback_page = navigation.action_performed('unknown',
+                                                fallback=fallback_class)
     assert navigation.page is fallback_page
     assert navigation.page_id is None
     assert fallback_page.wait_for_page_to_load.assert_called_once() is None
@@ -119,3 +131,8 @@ def test_action_performed_fallback(navigation, page_instance, default_page_class
 def test_get_credentials(navigation):
     """ Test get credentials """
     assert navigation.get_credentials('Administrator') == ('admin', 'pwd')
+
+
+def test_get_kwargs(navigation):
+    """ Test kwargs """
+    assert navigation.kwargs['variables']['foo'] == 'bar'

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -294,14 +294,15 @@ def test_navigation():
         page_mappings,
         credentials_mapping,
         skin,
-        skin_base_url
+        skin_base_url,
+        variables={},
     ) is navigation_instance
     assert navigation_class.assert_called_once_with(
         page_instance,
         default_page_class,
         page_mappings,
         credentials_mapping,
-        skin, skin_base_url) is None
+        skin, skin_base_url, variables={}) is None
 
 
 def test_test_run_identifier(test_run_identifier, skin):


### PR DESCRIPTION
navigation initialized with kwargs (including variables coming from pytest variables too)