### PR TITLE
Refactor init

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,11 @@ Changelog
 1.0.1 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Navigation will no more be initialized automatically with an open
+  browser by default since pypom_navigation is used by third party
+  plugins even for non UI plugins. This way we avoid to open
+  a browser if it is not needed and explicitly requested with a
+  set page or visit page
 
 
 1.0.0 (2017-12-19)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,11 +4,14 @@ Changelog
 1.0.1 (unreleased)
 ==================
 
-- Navigation will no more be initialized automatically with an open
+- navigation will no more be initialized automatically with an open
   browser by default since pypom_navigation is used by third party
   plugins even for non UI plugins. This way we avoid to open
   a browser if it is not needed and explicitly requested with a
   set page or visit page
+
+- you can override the default page timeout using a ``pytest-variables``
+  configuration named ``default_timeout``
 
 
 1.0.0 (2017-12-19)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,8 @@ Changelog
 - you can override the default page timeout using a ``pytest-variables``
   configuration named ``default_timeout``
 
+- add new method ``get_page_instance`` on navigation
+
 
 1.0.0 (2017-12-19)
 ==================

--- a/README.rst
+++ b/README.rst
@@ -33,6 +33,8 @@ It provides the core engine (pytest fixtures) needed by the strong opinionated s
 called `cookiecutter-qa`_ that let you generate a fully working QA testing hello world project based on
 Selenium/Splinter with just one command.
 
+It is also used by the pytest-play_ engine for collecting variables for tests parametrization.
+
 Tests
 ------------
 
@@ -70,3 +72,4 @@ If you encounter any problems, please `file an issue`_ along with a detailed des
 .. _`pip`: https://pypi.python.org/pypi/pip/
 .. _`PyPI`: https://pypi.python.org/pypi
 .. _`cookiecutter-qa`: https://github.com/tierratelematics/cookiecutter-qa
+.. _`pytest-play`: https://github.com/tierratelematics/pytest-play

--- a/pypom_navigation/navigation.py
+++ b/pypom_navigation/navigation.py
@@ -20,6 +20,7 @@ class Navigation(object):
                  credentials_mapping,
                  skin,
                  skin_base_url,
+                 request,
                  **kwargs):
         self.setPage(page)
         self.default_page_class = default_page_class
@@ -27,6 +28,7 @@ class Navigation(object):
         self.credentials_mapping = credentials_mapping
         self.skin = skin
         self.skin_base_url = skin_base_url
+        self.request = request
         self.kwargs = kwargs
 
     def setPage(self, page, page_id=None):
@@ -95,4 +97,12 @@ class Navigation(object):
 
     def _page_instance(self, page_id=None, fallback=None, **kwargs):
         page_class = self.get_page_class(page_id=page_id, fallback=fallback)
-        return page_class(self.page.driver, **kwargs)
+        return page_class(self.driver, **kwargs)
+
+    @property
+    def driver(self):
+        if self.page is not None:
+            value = self.page.driver
+        else:
+            value = self.request.getfixturevalue('browser')
+        return value

--- a/pypom_navigation/navigation.py
+++ b/pypom_navigation/navigation.py
@@ -55,7 +55,7 @@ class Navigation(object):
         """
         kwargs = self.merge_kwargs(kwargs)
         page_url = urljoin(self.skin_base_url, self.get_page_url(page_id))
-        page_instance = self._page_instance(page_id=page_id, **kwargs)
+        page_instance = self.get_page_instance(page_id=page_id, **kwargs)
         page_instance.driver.visit(page_url)
         page_instance.wait_for_page_to_load()
         self.setPage(page_instance, page_id=page_id)
@@ -66,7 +66,7 @@ class Navigation(object):
             mapped to the passed page_id
         """
         kwargs = self.merge_kwargs(kwargs)
-        page_instance = self._page_instance(page_id=page_id, **kwargs)
+        page_instance = self.get_page_instance(page_id=page_id, **kwargs)
         page_instance.wait_for_page_to_load()
         self.setPage(page_instance, page_id=page_id)
         return page_instance
@@ -81,7 +81,7 @@ class Navigation(object):
         if page_id:
             return self.update_page(page_id, **kwargs)
         else:
-            page_instance = self._page_instance(fallback=fallback, **kwargs)
+            page_instance = self.get_page_instance(fallback=fallback, **kwargs)
             page_instance.wait_for_page_to_load()
             self.setPage(page_instance)
             return page_instance
@@ -107,7 +107,8 @@ class Navigation(object):
             page_id=page_id,
             fallback=fallback)
 
-    def _page_instance(self, page_id=None, fallback=None, **kwargs):
+    def get_page_instance(self, page_id=None, fallback=None, **kwargs):
+        """ Get a fresh page instance """
         page_class = self.get_page_class(page_id=page_id, fallback=fallback)
         return page_class(self.driver, **kwargs)
 

--- a/pypom_navigation/navigation.py
+++ b/pypom_navigation/navigation.py
@@ -33,9 +33,10 @@ class Navigation(object):
         """ Set wrapping page and update reference links
             for page and navigation
         """
-        page.navigation = self
         self.page = page
         self.page_id = page_id
+        if page is not None:
+            page.navigation = self
 
     def visit_page(self, page_id, **kwargs):
         """ Visit page id reference in navigation

--- a/pypom_navigation/navigation.py
+++ b/pypom_navigation/navigation.py
@@ -21,6 +21,7 @@ class Navigation(object):
                  skin,
                  skin_base_url,
                  request,
+                 variables,
                  **kwargs):
         self.setPage(page)
         self.default_page_class = default_page_class
@@ -29,6 +30,7 @@ class Navigation(object):
         self.skin = skin
         self.skin_base_url = skin_base_url
         self.request = request
+        self.variables = variables
         self.kwargs = kwargs
 
     def setPage(self, page, page_id=None):
@@ -40,10 +42,18 @@ class Navigation(object):
         if page is not None:
             page.navigation = self
 
+    def merge_kwargs(self, keyword_args):
+        """ merge keyword args with default keywordargs """
+        kwargs = self.kwargs.copy()
+        new_kwargs = keyword_args.copy()
+        kwargs.update(new_kwargs)
+        return kwargs
+
     def visit_page(self, page_id, **kwargs):
         """ Visit page id reference in navigation
             class
         """
+        kwargs = self.merge_kwargs(kwargs)
         page_url = urljoin(self.skin_base_url, self.get_page_url(page_id))
         page_instance = self._page_instance(page_id=page_id, **kwargs)
         page_instance.driver.visit(page_url)
@@ -55,6 +65,7 @@ class Navigation(object):
         """ Update the wrapped page with the appropriate instance
             mapped to the passed page_id
         """
+        kwargs = self.merge_kwargs(kwargs)
         page_instance = self._page_instance(page_id=page_id, **kwargs)
         page_instance.wait_for_page_to_load()
         self.setPage(page_instance, page_id=page_id)
@@ -64,6 +75,7 @@ class Navigation(object):
         """ Update the wrapped page with the appropriate instance
             referenced by the given action on the current page
         """
+        kwargs = self.merge_kwargs(kwargs)
         page_mapping = self.page_mappings[self.page_id]
         page_id = page_mapping.get('actions', {}).get(action)
         if page_id:
@@ -101,6 +113,9 @@ class Navigation(object):
 
     @property
     def driver(self):
+        """ Return page driver or a fresh browser fixture to be used as driver
+            for first initialization
+        """
         if self.page is not None:
             value = self.page.driver
         else:

--- a/pypom_navigation/plugin.py
+++ b/pypom_navigation/plugin.py
@@ -193,7 +193,7 @@ def navigation(navigation_class,
         skin,
         skin_base_url,
         request,
-        variables=variables,
+        variables,
         timeout=default_timeout)
     return nav
 

--- a/pypom_navigation/plugin.py
+++ b/pypom_navigation/plugin.py
@@ -175,6 +175,7 @@ def navigation(navigation_class,
                credentials_mapping,
                skin,
                skin_base_url,
+               request,
                variables,
                default_timeout):
     """ Wraps a page and a page mappings accessible by
@@ -191,6 +192,7 @@ def navigation(navigation_class,
         credentials_mapping,
         skin,
         skin_base_url,
+        request,
         variables=variables,
         timeout=default_timeout)
     return nav

--- a/pypom_navigation/plugin.py
+++ b/pypom_navigation/plugin.py
@@ -6,7 +6,6 @@ created in the ``pypom_navigation`` package:
 .. graphviz::
 
    digraph {
-      base_page;
       bdd_vars;
       browser;
       credentials_mapping;
@@ -16,7 +15,6 @@ created in the ``pypom_navigation`` package:
       navigation;
       navigation_class;
       now;
-      page_instance;
       page_mappings,
       parametrizer;
       parametrizer_class;
@@ -27,23 +25,19 @@ created in the ``pypom_navigation`` package:
       test_run_identifier;
       variables;
       default_timeout;
-      default_timeout -> {base_page};
-      base_page -> {page_instance};
       bdd_vars -> {parametrizer};
-      browser -> {base_page};
       credentials_mapping -> {navigation};
-      default_page_class -> {base_page navigation};
+      default_page_class -> {navigation};
       default_pages -> {default_page_class};
       navigation_class -> {navigation};
       now -> {bdd_vars};
-      page_instance -> {navigation};
-      page_mappings -> {default_page_class base_page navigation};
+      page_mappings -> {default_page_class navigation};
       parametrizer_class -> {parametrizer};
       request -> {skip_by_skin_names};
       skin -> {skin_base_url credentials_mapping default_page_class
-               base_page navigation skip_by_skin_names
+               navigation skip_by_skin_names
                test_run_identifier bdd_vars};
-      skin_base_url -> {base_page navigation};
+      skin_base_url -> {navigation};
       test_run_identifier -> {bdd_vars};
       variables -> {skin_base_url credentials_mapping};
    }
@@ -58,7 +52,6 @@ import datetime
 
 from .util import (
     get_page_class,
-    page_factory,
 )
 from .navigation import Navigation
 from .parametrizer import Parametrizer
@@ -176,43 +169,14 @@ def default_timeout():
 
 
 @pytest.fixture
-def base_page(skin_base_url, browser, default_page_class, page_mappings, skin,
-              default_timeout):
-    """ Base page instance """
-    page = page_factory(
-        skin_base_url,
-        browser,
-        default_page_class,
-        page_mappings,
-        skin,
-        timeout=default_timeout)
-
-    return page
-
-
-@pytest.fixture
-def page_instance(base_page):
-    """ Initialize base page.
-        You can override this fixture in order to customize
-        the page initialization (eg: some sites needs auth
-        after, other sites before)
-    """
-
-    # maximize window
-    base_page.driver.driver.maximize_window()
-
-    return base_page
-
-
-@pytest.fixture
 def navigation(navigation_class,
-               page_instance,
                default_page_class,
                page_mappings,
                credentials_mapping,
                skin,
                skin_base_url,
-               variables):
+               variables,
+               default_timeout):
     """ Wraps a page and a page mappings accessible by
         pages.
 
@@ -221,13 +185,14 @@ def navigation(navigation_class,
         change.
     """
     nav = navigation_class(
-        page_instance,
+        None,      # backwards compatibility
         default_page_class,
         page_mappings,
         credentials_mapping,
         skin,
         skin_base_url,
-        variables=variables,)
+        variables=variables,
+        timeout=default_timeout)
     return nav
 
 

--- a/pypom_navigation/plugin.py
+++ b/pypom_navigation/plugin.py
@@ -24,7 +24,7 @@ created in the ``pypom_navigation`` package:
       skip_by_skin_names;
       test_run_identifier;
       variables;
-      default_timeout;
+      default_timeout -> {variables};
       bdd_vars -> {parametrizer};
       credentials_mapping -> {navigation};
       default_page_class -> {navigation};
@@ -163,9 +163,9 @@ def default_page_class(skin, page_mappings, default_pages):
 
 
 @pytest.fixture
-def default_timeout():
+def default_timeout(variables):
     """ Default page timeout """
-    return 10
+    return variables.get('default_timeout', 10)
 
 
 @pytest.fixture

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -8,7 +8,12 @@ def variables():
 
 
 @pytest.fixture
-def page_instance():
+def browser():
+    return MagicMock()
+
+
+@pytest.fixture
+def page():
     return MagicMock()
 
 
@@ -63,7 +68,7 @@ def test_navigation_init(
     assert navigation.page_id is None
 
 
-def test_visit_page(navigation, page_instance, default_page_class):
+def test_visit_page(navigation, default_page_class, browser):
     """ Test visit page """
     home_page = navigation.visit_page('HomePage')
     assert navigation.page is home_page
@@ -72,57 +77,57 @@ def test_visit_page(navigation, page_instance, default_page_class):
         'https://skin1-coolsite.com/home') is None
     assert home_page.wait_for_page_to_load.assert_called_once() is None
     assert default_page_class.assert_called_once_with(
-        page_instance.driver) is None
+        browser) is None
     assert default_page_class.return_value.navigation is navigation
 
 
-def test_update_page(navigation, page_instance, default_page_class):
+def test_update_page(navigation, default_page_class, browser):
     """ Test update page """
     home_page = navigation.update_page('HomePage')
     assert navigation.page is home_page
     assert navigation.page_id == 'HomePage'
     assert home_page.wait_for_page_to_load.assert_called_once() is None
     assert default_page_class.assert_called_once_with(
-        page_instance.driver) is None
+        browser) is None
     assert default_page_class.return_value.navigation is navigation
 
 
-def test_action_performed(navigation, page_instance, default_page_class):
+def test_action_performed(navigation, page, default_page_class, browser):
     """ Test visit page """
-    navigation.setPage(page_instance, 'AnotherPage')
+    navigation.setPage(page, 'AnotherPage')
     home_page = navigation.action_performed('back')
     assert navigation.page is home_page
     assert navigation.page_id == 'HomePage'
     assert home_page.wait_for_page_to_load.assert_called_once() is None
     assert default_page_class.assert_called_once_with(
-         page_instance.driver) is None
+         page.driver) is None
     assert default_page_class.return_value.navigation is navigation
 
 
-def test_action_performed_no_action_mapped(navigation, page_instance,
+def test_action_performed_no_action_mapped(navigation, page,
                                            default_page_class):
     """ Test visit page """
-    navigation.setPage(page_instance, 'AnotherPage')
+    navigation.setPage(page, 'AnotherPage')
     default_page = navigation.action_performed('unknown')
     assert navigation.page is default_page
     assert navigation.page_id is None
     assert default_page.wait_for_page_to_load.assert_called_once() is None
     assert default_page_class.assert_called_once_with(
-        page_instance.driver) is None
+        page.driver) is None
     assert default_page_class.return_value.navigation is navigation
 
 
-def test_action_performed_fallback(navigation, page_instance,
+def test_action_performed_fallback(navigation, page,
                                    default_page_class):
     """ Test visit page """
-    navigation.setPage(page_instance, 'AnotherPage')
+    navigation.setPage(page, 'AnotherPage')
     fallback_class = MagicMock()
     fallback_page = navigation.action_performed('unknown',
                                                 fallback=fallback_class)
     assert navigation.page is fallback_page
     assert navigation.page_id is None
     assert fallback_page.wait_for_page_to_load.assert_called_once() is None
-    assert fallback_class.assert_called_once_with(page_instance.driver) is None
+    assert fallback_class.assert_called_once_with(page.driver) is None
     assert fallback_class.return_value.navigation is navigation
 
 

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -68,7 +68,8 @@ def test_navigation_init(
     assert navigation.page_id is None
 
 
-def test_visit_page(navigation, default_page_class, browser):
+def test_visit_page(navigation, default_page_class, browser,
+                    default_timeout):
     """ Test visit page """
     home_page = navigation.visit_page('HomePage')
     assert navigation.page is home_page
@@ -77,22 +78,24 @@ def test_visit_page(navigation, default_page_class, browser):
         'https://skin1-coolsite.com/home') is None
     assert home_page.wait_for_page_to_load.assert_called_once() is None
     assert default_page_class.assert_called_once_with(
-        browser) is None
+        browser, timeout=default_timeout) is None
     assert default_page_class.return_value.navigation is navigation
 
 
-def test_update_page(navigation, default_page_class, browser):
+def test_update_page(navigation, default_page_class, browser,
+                     default_timeout):
     """ Test update page """
     home_page = navigation.update_page('HomePage')
     assert navigation.page is home_page
     assert navigation.page_id == 'HomePage'
     assert home_page.wait_for_page_to_load.assert_called_once() is None
     assert default_page_class.assert_called_once_with(
-        browser) is None
+        browser, timeout=default_timeout) is None
     assert default_page_class.return_value.navigation is navigation
 
 
-def test_action_performed(navigation, page, default_page_class, browser):
+def test_action_performed(navigation, page, default_page_class, browser,
+                          default_timeout):
     """ Test visit page """
     navigation.setPage(page, 'AnotherPage')
     home_page = navigation.action_performed('back')
@@ -100,12 +103,13 @@ def test_action_performed(navigation, page, default_page_class, browser):
     assert navigation.page_id == 'HomePage'
     assert home_page.wait_for_page_to_load.assert_called_once() is None
     assert default_page_class.assert_called_once_with(
-         page.driver) is None
+         page.driver, timeout=default_timeout) is None
     assert default_page_class.return_value.navigation is navigation
 
 
 def test_action_performed_no_action_mapped(navigation, page,
-                                           default_page_class):
+                                           default_page_class,
+                                           default_timeout):
     """ Test visit page """
     navigation.setPage(page, 'AnotherPage')
     default_page = navigation.action_performed('unknown')
@@ -113,12 +117,12 @@ def test_action_performed_no_action_mapped(navigation, page,
     assert navigation.page_id is None
     assert default_page.wait_for_page_to_load.assert_called_once() is None
     assert default_page_class.assert_called_once_with(
-        page.driver) is None
+        page.driver, timeout=default_timeout) is None
     assert default_page_class.return_value.navigation is navigation
 
 
 def test_action_performed_fallback(navigation, page,
-                                   default_page_class):
+                                   default_page_class, default_timeout):
     """ Test visit page """
     navigation.setPage(page, 'AnotherPage')
     fallback_class = MagicMock()
@@ -127,7 +131,8 @@ def test_action_performed_fallback(navigation, page,
     assert navigation.page is fallback_page
     assert navigation.page_id is None
     assert fallback_page.wait_for_page_to_load.assert_called_once() is None
-    assert fallback_class.assert_called_once_with(page.driver) is None
+    assert fallback_class.assert_called_once_with(
+        page.driver, timeout=default_timeout) is None
     assert fallback_class.return_value.navigation is navigation
 
 
@@ -136,6 +141,20 @@ def test_get_credentials(navigation):
     assert navigation.get_credentials('Administrator') == ('admin', 'pwd')
 
 
-def test_get_kwargs(navigation):
+def test_get_kwargs(navigation, default_timeout):
     """ Test kwargs """
-    assert navigation.kwargs['variables']['foo'] == 'bar'
+    assert navigation.kwargs['timeout'] == default_timeout
+
+
+def test_merge_kwargs(navigation, default_timeout):
+    """ Test kwargs """
+    assert navigation.kwargs['timeout'] == default_timeout
+    assert 'new' not in navigation.kwargs
+    merged = navigation.merge_kwargs(dict(new=1))
+    assert merged['timeout'] == default_timeout
+    assert merged['new'] == 1
+
+
+def test_variables(navigation):
+    """ Test kwargs """
+    assert navigation.variables['foo'] == 'bar'

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -47,7 +47,6 @@ def default_page_class():
 
 def test_navigation_init(
         navigation,
-        page_instance,
         default_page_class,
         page_mappings,
         credentials_mapping,
@@ -55,8 +54,7 @@ def test_navigation_init(
         skin_base_url):
     """ Navigation init """
 
-    assert navigation.page is page_instance
-    assert page_instance.navigation is navigation
+    assert navigation.page is None
     assert navigation.default_page_class is default_page_class
     assert navigation.page_mappings == page_mappings
     assert navigation.credentials_mapping == credentials_mapping

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -225,45 +225,6 @@ def test_skip_by_skin_names_import(testdir, credentials_file):
     assert result.ret == 0
 
 
-def test_base_page(default_timeout):
-    from mock import patch
-    from mock import Mock
-    from pypom_navigation.plugin import base_page
-
-    page_mock = Mock()
-
-    with patch('pypom_navigation.plugin.page_factory') as page_factory:
-        page_factory.return_value = page_mock
-
-        skin_base_url = None
-        browser = None
-        default_page_class = None
-        page_mappings = None
-        skin = None
-        base_page(skin_base_url, browser,
-                  default_page_class, page_mappings, skin, default_timeout)
-        assert page_factory.assert_called_once_with(
-            skin_base_url,
-            browser,
-            default_page_class,
-            page_mappings,
-            skin, timeout=default_timeout) is None
-
-
-def test_page_instance():
-    """ page instance fixture customizes the base page (for example)
-        by default maximize windows has called but you can override it
-    """
-    from mock import MagicMock
-    from pypom_navigation.plugin import page_instance
-
-    base_page = MagicMock()
-    assert page_instance(base_page) is base_page
-
-    assert base_page.driver.driver.maximize_window \
-        .assert_called_once_with() is None
-
-
 def test_navigation():
     """ Test navigation  """
     from mock import Mock

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -234,29 +234,36 @@ def test_navigation():
     navigation_class = Mock()
     navigation_class.return_value = navigation_instance
 
-    page_instance = object()
     default_page_class = object()
     page_mappings = object()
     credentials_mapping = object()
     skin = object()
     skin_base_url = object()
+    request = object()
+    variables = {}
+    default_timeout = 15
 
     assert navigation(
         navigation_class,
-        page_instance,
         default_page_class,
         page_mappings,
         credentials_mapping,
         skin,
         skin_base_url,
-        variables={},
+        request,
+        variables,
+        default_timeout,
     ) is navigation_instance
     assert navigation_class.assert_called_once_with(
-        page_instance,
+        None,
         default_page_class,
         page_mappings,
         credentials_mapping,
-        skin, skin_base_url, variables={}) is None
+        skin,
+        skin_base_url,
+        request,
+        variables=variables,
+        timeout=default_timeout) is None
 
 
 def test_test_run_identifier(test_run_identifier, skin):

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -262,7 +262,7 @@ def test_navigation():
         skin,
         skin_base_url,
         request,
-        variables=variables,
+        variables,
         timeout=default_timeout) is None
 
 


### PR DESCRIPTION
Navigation will no more be initialized automatically with an open browser by default since pypom_navigation is used by third party plugins even for non UI plugins. This way we avoid to open a browser if it is not needed and explicitly requested with a set page or visit page

Wiped out fixtures (no soft deprecation, package is in pre alpha status):
* base_page
* page_instance